### PR TITLE
fix: resolve Git dubious ownership error for mounted volume

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -59,7 +59,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         libopenblas0 \
         libopencv-core406 libopencv-imgproc406 libopencv-imgcodecs406 \
         ca-certificates openssl git \
-    && rm -rf /var/lib/apt/lists/*
+    && rm -rf /var/lib/apt/lists/* \
+    && git config --system --add safe.directory /app/AzurLaneAutoScript
 
 COPY --from=builder ${PYROOT} ${PYROOT}
 COPY --from=builder /opt/platform-tools /opt/platform-tools


### PR DESCRIPTION
### What does this PR do?
Marks `/app/AzurLaneAutoScript` as a Git safe directory in the Dockerfile.

### Why is this necessary?
Fixes the `fatal: detected dubious ownership` error when running Git commands. This occurs in Git >= 2.35.2 due to UID mismatches when a host user mounts a local repo into the container running as root. 

### Changes
- Added `git config --system --add safe.directory /app/AzurLaneAutoScript` to the Dockerfile. 

### Related Issue
Fixes #2 